### PR TITLE
use template literals, arrow functions and shorthand properties

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,7 @@
 
 const K7 = require('./k7');
 
-exports.register = function (server, options, next) {
+exports.register = (server, options, next) => {
   const k7 = new K7(server, options);
 
   server.expose('k7', k7);

--- a/lib/k7.js
+++ b/lib/k7.js
@@ -16,7 +16,6 @@ internals.defaults = {
 
 module.exports = internals.K7 = function (server, options) {
   options = options || {};
-
   Hoek.assert(this instanceof internals.K7, 'K7 must be instantiated using new');
   Hoek.assert(server, 'server required to create k7');
 
@@ -43,11 +42,11 @@ internals.K7.prototype.load = function (cb) {
 
   const adapterName = Hoek.reach(Adapter, 'attributes.name', reachOptions) || 'adapter';
 
-  Hoek.assert(typeof Adapter === 'function', adapterName + ' must be a constructor function');
+  Hoek.assert(typeof Adapter === 'function', `${adapterName} must be a constructor function`);
 
   this.adapter = new Adapter(this.settings);
 
-  Hoek.assert(typeof this.adapter.load === 'function', adapterName + ' must be a load function');
+  Hoek.assert(typeof this.adapter.load === 'function', `${adapterName} must be a load function`);
 
   this.database = this.adapter.load();
 };

--- a/test/index.js
+++ b/test/index.js
@@ -29,7 +29,7 @@ describe('K7', () => {
     server = new Hapi.Server();
     const register = {
       register: require('../index'),
-      options: options
+      options
     };
 
     server.register([register], (err) => {
@@ -53,7 +53,7 @@ describe('K7', () => {
 
     const register = {
       register: require('../index'),
-      options: options
+      options
     };
 
     server.register([register], (err) => {
@@ -76,7 +76,7 @@ describe('K7', () => {
 
     const register = {
       register: require('../index'),
-      options: options
+      options
     };
 
     server.register([register], (err) => {


### PR DESCRIPTION
Also there's a use case for default parameters but aren't implemented in Node v4. Please consider adding Babel to use ES2015 full spectrum.
